### PR TITLE
修正 GWT Unmarshaller 可能造成的錯誤

### DIFF
--- a/library/src/main/java/com/dtc/fhir/repository/gwt/BaseGwtRepo.java
+++ b/library/src/main/java/com/dtc/fhir/repository/gwt/BaseGwtRepo.java
@@ -3,7 +3,7 @@ package com.dtc.fhir.repository.gwt;
 import com.dtc.fhir.gwt.*;
 import com.dtc.fhir.gwt.extension.PageResult;
 import com.dtc.fhir.repository.BaseRepo;
-import com.dtc.fhir.unmarshal.GenericUnmarshaller;
+import com.dtc.fhir.unmarshal.GwtUnmarshaller;
 import com.dtc.fhir.repository.Constant;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
@@ -64,7 +64,7 @@ public abstract class BaseGwtRepo<T> extends BaseRepo {
 		if(xml == null || xml.trim().equals("")) {
 			return null;
 		}
-		return GenericUnmarshaller.unmarshal(entityClass, xml);
+		return GwtUnmarshaller.unmarshal(entityClass, xml);
 	}
 
 	/**
@@ -76,7 +76,7 @@ public abstract class BaseGwtRepo<T> extends BaseRepo {
 		}
 		List<T> resources = Lists.newArrayList();
 
-		Bundle bundle = GenericUnmarshaller.unmarshal(Bundle.class, xml);
+		Bundle bundle = GwtUnmarshaller.unmarshal(Bundle.class, xml);
 
 		if (bundle == null) { return null; }
 

--- a/library/src/main/java/com/dtc/fhir/unmarshal/GenericUnmarshaller.java
+++ b/library/src/main/java/com/dtc/fhir/unmarshal/GenericUnmarshaller.java
@@ -9,22 +9,37 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
 public class GenericUnmarshaller {
-
-	private static Unmarshaller unmarshaller;
+	private static JAXBContext context;
 
 	static {
 		try {
-			JAXBContext context = JAXBContext.newInstance("com.dtc.fhir.gwt");
-			unmarshaller = context.createUnmarshaller();
+			context = JAXBContext.newInstance("com.dtc.fhir.gwt");
 		} catch (JAXBException e) {
 			e.printStackTrace();
 		}
 	}
 
+	@SuppressWarnings("unchecked")
 	public static <T> T unmarshal(Class<T> clazz, String xml) {
+		if (context == null) {
+			throw new UnsupportedOperationException("JAXBContext of \"com.dtc.fhir.gwt\" initial failed.");
+		}
+
+		//unmarshaller 應該沒有保證 thread-safe
+		//所以每次 unmarshal 都重新產生一個新的 instance
+		Unmarshaller unmarshaller;
+
+		try {
+			unmarshaller = context.createUnmarshaller();
+		} catch (JAXBException e) {
+			e.printStackTrace();
+			throw new UnsupportedOperationException("Unmarshaller create failed");
+		}
+
 		try {
 			InputStream inputStream = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
 			Object object = ((JAXBElement<T>) unmarshaller.unmarshal(inputStream)).getValue();
+
 			if(clazz.isInstance(object)) {
 				return (T) object;
 			} else {
@@ -33,6 +48,7 @@ public class GenericUnmarshaller {
 		} catch (JAXBException e) {
 			e.printStackTrace();
 		}
+
 		return null;
 	}
 }

--- a/library/src/main/java/com/dtc/fhir/unmarshal/GwtUnmarshaller.java
+++ b/library/src/main/java/com/dtc/fhir/unmarshal/GwtUnmarshaller.java
@@ -8,7 +8,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
-public class GenericUnmarshaller {
+public class GwtUnmarshaller {
 	private static JAXBContext context;
 
 	static {


### PR DESCRIPTION
~~好消息好消息，報仇雪恨的機會來了！~~

之前沒有考慮到 `unmarshaller` 可能並不是 thread-safe，實驗證明是有出現一些靈異現象 :-1: 。不回到你原本的作法是因為：

* JAXBContext 可以只建立一個 instance 就好，效率會快很多（想像一下每次 JAXBContext 建立都要掃一遍 package...... :scream: ）
* static API 還是比較簡潔一點

`createUnmarshaller()` 已經查驗過，至少目前的實作是會建立新的 instance（[reference](http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/6-b14/com/sun/xml/internal/bind/v2/runtime/JAXBContextImpl.java#JAXBContextImpl.createUnmarshaller%28%29)）

--------

另外，是目前還沒有改、但是想要在這個 PR 一起解決的議題。我想要讓這個 class 改名為 `GwtUnmarshaller`（之類的），畢竟這不是真的泛用的 unmarshall。

不確定你是不是能接受這個提議，所以先問一下...